### PR TITLE
Markdown support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.egg-info/
 dist/
 .venv
+build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Changelog
 
 *Release date: TBD*
 
+* Add support for markdown files and time information
+  [#18](https://github.com/jdillard/sphinx-gitstamp/pull/18)
 * Fix Path use for Sphinx 8
   [#16](https://github.com/jdillard/sphinx-gitstamp/pull/16)
 * Clean up how package versions are handled

--- a/README.rst
+++ b/README.rst
@@ -29,6 +29,13 @@ For example:
    # Date format for git timestamps
    gitstamp_fmt = "%b %d, %Y"
 
+Set the value of ``gitstamp_file_types`` in **conf.py** to the list of file extensions to support.
+For example:
+
+.. code-block:: python
+
+   gitstamp_file_types = ["rst", "md"]
+
 Add ``gitstamp`` to the jinja template, for example:
 
 .. code-block:: jinja

--- a/README.rst
+++ b/README.rst
@@ -29,13 +29,6 @@ For example:
    # Date format for git timestamps
    gitstamp_fmt = "%b %d, %Y"
 
-Set the value of ``gitstamp_file_types`` in **conf.py** to the list of file extensions to support.
-For example:
-
-.. code-block:: python
-
-   gitstamp_file_types = ["rst", "md"]
-
 Add ``gitstamp`` to the jinja template, for example:
 
 .. code-block:: jinja

--- a/sphinx_gitstamp/__init__.py
+++ b/sphinx_gitstamp/__init__.py
@@ -55,7 +55,6 @@ def page_context_handler(app, pagename, templatename, context, doctree):
             # that involves getting the source/output pair into the extension.
             return
         dt_object = datetime.datetime.strptime(updated, "%Y-%m-%d %H:%M:%S %z")
-        print(dt_object)
         context["gitstamp"] = dt_object.strftime(app.config.gitstamp_fmt)
     except git.exc.GitCommandError:
         # File doesn't exist or something else went wrong.

--- a/sphinx_gitstamp/__init__.py
+++ b/sphinx_gitstamp/__init__.py
@@ -31,6 +31,7 @@ def find_file_extension(file_name, possible_extensions):
             return file_path
     return None
 
+
 def page_context_handler(app, pagename, templatename, context, doctree):
     import git
 
@@ -58,9 +59,7 @@ def page_context_handler(app, pagename, templatename, context, doctree):
         context["gitstamp"] = dt_object.strftime(app.config.gitstamp_fmt)
     except git.exc.GitCommandError:
         # File doesn't exist or something else went wrong.
-        raise errors.ExtensionError(
-            "Can't fetch git history for %s." % file_path
-        )
+        raise errors.ExtensionError("Can't fetch git history for %s." % file_path)
     except ValueError:
         # Datestamp can't be parsed.
         app.info(

--- a/sphinx_gitstamp/__init__.py
+++ b/sphinx_gitstamp/__init__.py
@@ -26,7 +26,7 @@ __version__ = "0.4.0"
 
 def find_file_extension(file_name, possible_extensions):
     for ext in possible_extensions:
-        file_path = os.path.join(file_name, f".{ext}")
+        file_path = str(file_name) + f".{ext}"
         if os.path.exists(file_path):
             return file_path
     return None
@@ -55,6 +55,7 @@ def page_context_handler(app, pagename, templatename, context, doctree):
             # that involves getting the source/output pair into the extension.
             return
         dt_object = datetime.datetime.strptime(updated, "%Y-%m-%d %H:%M:%S %z")
+        print(dt_object)
         context["gitstamp"] = dt_object.strftime(app.config.gitstamp_fmt)
     except git.exc.GitCommandError:
         # File doesn't exist or something else went wrong.

--- a/sphinx_gitstamp/__init__.py
+++ b/sphinx_gitstamp/__init__.py
@@ -24,9 +24,9 @@ __version__ = "0.4.0"
 # Output to June 7, 2017
 
 
-def find_file_extension(file_name, possible_extensions):
-    for ext in possible_extensions:
-        file_path = str(file_name) + f".{ext}"
+def find_file_extension(file_name, source_suffix):
+    for ext, _ in source_suffix.items():
+        file_path = str(file_name) + ext
         if os.path.exists(file_path):
             return file_path
     return None
@@ -43,7 +43,7 @@ def page_context_handler(app, pagename, templatename, context, doctree):
     fullpagename = Path(app.confdir, pagename)
 
     # Find file extension. If not in the list we skip this file.
-    file_path = find_file_extension(fullpagename, app.config.gitstamp_file_types)
+    file_path = find_file_extension(fullpagename, app.config.source_suffix)
     if file_path is None:
         return
 
@@ -104,7 +104,6 @@ The error was: {e}
 # know what the build output format is.
 def setup(app):
     app.add_config_value("gitstamp_fmt", "%b %d, %Y", "html")
-    app.add_config_value("gitstamp_file_types", ["rst", "md"], "html")
     app.connect("builder-inited", what_build_am_i)
 
     return {


### PR DESCRIPTION
Adds the ability to specify supported file types using `gitstamp_file_types = ["rst", "md"]` in `conf.py`. (Would close #11.)

Also expands the `datetime` information to `%Y-%m-%d %H:%M:%S %z` for additional flexibility with hour and minute.